### PR TITLE
add the ability to set configuration options when creating a new topic

### DIFF
--- a/lib/kafka/admin.rb
+++ b/lib/kafka/admin.rb
@@ -32,14 +32,16 @@ module Kafka
     #   to complete. Total request execution time may be longer than timeout
     #   due to multiple operations being done. Defaults to `socket.timeout.ms`
     #   config setting.
+    # @param topic_config [Hash] Topic level configuration. 
     #
     # @return [Kafka::Admin::FFI::CreateTopicsResult, nil] Response from the
     #   cluster with details about the new topic or any errors that occurred.
     #   Returns nil when the operation timed out.
-    def create_topic(name, partitions, replication_factor, wait: true, validate: false, timeout: nil)
+    def create_topic(name, partitions, replication_factor, wait: true, validate: false, timeout: nil, topic_config: {})
       req = ::Kafka::FFI::Admin::NewTopic.new(name, partitions, replication_factor)
       opts = new_options(:create_topics, wait: wait, validate: validate, timeout: timeout)
 
+      topic_config.each_pair {|k,v| req.set_config(k.to_s,v.to_s) }
       @client.create_topics(req, options: opts)
     ensure
       opts.destroy


### PR DESCRIPTION
Hello!

Thanks so much for your work on this!  It's good to see support for later versions of Kafka.  

As the title suggests, this PR makes it possible to pass a `topic_config` hash when creating a new topic.

```
  admin = Kafka::Admin.new(Kafka::Config.new("bootstrap.servers": "kafka:9092"))

  config = {                                                           
    "retention.ms": "-1",                                              
    "cleanup.policy": "compact",                                       
    "max.compaction.lag.ms": (1.day * 1000)
  }

  admin.create_topic_with_options(TOPIC, 1, 1, topic_config: config)                                                
  admin.close                                                                      
```

I didn't see any tests for the outer `Admin` class so I didn't add one. If you'd like to provide me a bit of guidance on adding one I'd be happy to set it up.  Thanks!